### PR TITLE
added link to RapidAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,27 @@
 
 Client for Google Translate API
 
+<div style="margin: 25px;">
+<a href="https://rapidapi.com/package/GoogleTranslate/functions?utm_source=GoogleTranslateGitHub-Ruby&utm_medium=button&utm_content=Vendor_GitHub" style="
+    all: initial;
+    background-color: #498FE1;
+    border-width: 0;
+    border-radius: 5px;
+    padding: 10px 20px;
+    color: white;
+    font-family: 'Helvetica';
+    font-size: 12pt;
+    background-image: url(https://scdn.rapidapi.com/logo-small.png);
+    background-size: 25px;
+    background-repeat: no-repeat;
+    background-position-y: center;
+    background-position-x: 10px;
+    padding-left: 44px;
+    cursor: pointer;">
+  Run now on <b>RapidAPI</b>
+</a>
+</div>
+
 ## Installation
 
 Add this line to your application's Gemfile:


### PR DESCRIPTION
I've added a link to the Google Translate functions page in RapidAPI. It'll definitely help devs understand and test the API before implementation.